### PR TITLE
Import MIT license template (#1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+PHP Git Ignore
+Copyright (c) 2019 Dan Stevens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
This commit would add a top-level `LICENSE` file.  I'm not the original author, but I'm suggesting the change via PR.  The content is based on combining the following:

1. The `composer.json` file lists the `license` as `MIT`. This is what appears in the Packagist listing (https://packagist.org/packages/togos/gitignore) and in the `composer license` report.
2. The Github account and the commit list indicate TOGoS (Dan Stevens) as the author.
3. All the commits are from April 2019.
4. The template at https://opensource.org/licenses/MIT or https://github.com/totten/license-data/blob/master/licenses/MIT.txt is typical of "MIT" licensing.